### PR TITLE
Removed all plugin eager task resolution from the configuration phase

### DIFF
--- a/plugin/src/main/kotlin/io/github/fletchmckee/ktjni/KtjniPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/fletchmckee/ktjni/KtjniPlugin.kt
@@ -9,14 +9,16 @@ import io.github.fletchmckee.ktjni.internal.configureKotlinJvm
 import io.github.fletchmckee.ktjni.internal.configureKotlinMultiplatform
 import io.github.fletchmckee.ktjni.tasks.KtjniTask
 import io.github.fletchmckee.ktjni.util.GROUP
+import io.github.fletchmckee.ktjni.util.taskSuffix
 import io.github.fletchmckee.ktjni.util.titleCase
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.scala.ScalaCompile
 
@@ -83,11 +85,14 @@ public class KtjniPlugin : Plugin<Project> {
   ) {
     plugins.withType(JavaBasePlugin::class.java) {
       val javaExtension = extensions.getByName("sourceSets") as SourceSetContainer
-      javaExtension.all {
-        val compileTaskProvider = tasks.named(compileJavaTaskName, JavaCompile::class.java)
-        registerJavaHeaderTask(
+      javaExtension.configureEach {
+        val compileSourceDir = tasks.named(compileJavaTaskName, JavaCompile::class.java)
+          .flatMap { it.destinationDirectory }
+
+        registerKtjniTask(
+          language = "java",
           sourceSetName = name,
-          compileTaskProvider = compileTaskProvider,
+          compileSourceDir = compileSourceDir,
           headerOutputDir = headerOutputDir,
           aggregate = aggregate,
         )
@@ -102,66 +107,44 @@ public class KtjniPlugin : Plugin<Project> {
     plugins.withId(PluginId.Scala.id) {
       // The scala plugin also applies the java plugin.
       val sourceSets = extensions.getByName("sourceSets") as SourceSetContainer
-      sourceSets.all {
-        val compileTaskProvider = tasks.named(getCompileTaskName("scala"), ScalaCompile::class.java)
-        registerScalaHeaderTask(
+      sourceSets.configureEach {
+        val compileSourceDir = tasks.named(getCompileTaskName("scala"), ScalaCompile::class.java)
+          .flatMap { it.destinationDirectory }
+
+        registerKtjniTask(
+          language = "scala",
           sourceSetName = name,
-          compileTaskProvider = compileTaskProvider,
+          compileSourceDir = compileSourceDir,
           headerOutputDir = headerOutputDir,
           aggregate = aggregate,
         )
       }
     }
   }
+}
 
-  private fun Project.registerJavaHeaderTask(
-    sourceSetName: String,
-    compileTaskProvider: TaskProvider<JavaCompile>,
-    headerOutputDir: DirectoryProperty,
-    aggregate: ConfigurableFileCollection,
-  ) {
-    val taskName = "generateJava${sourceSetName.titleCase}JniHeaders"
+internal fun Project.registerKtjniTask(
+  language: String,
+  sourceSetName: String,
+  compileSourceDir: Provider<Directory>,
+  headerOutputDir: DirectoryProperty,
+  aggregate: ConfigurableFileCollection,
+  target: String = "", // For Kotlin Multiplatform
+) {
+  val taskSuffix = sourceSetName.taskSuffix(target)
+  val taskName = "generate${language.titleCase}${taskSuffix.titleCase}JniHeaders"
 
-    val generateJniHeadersTask = tasks.register(taskName, KtjniTask::class.java) {
-      sourceDir.set(
-        compileTaskProvider.flatMap { it.destinationDirectory },
-      )
+  val generateJniHeadersTask = tasks.register(taskName, KtjniTask::class.java) {
+    sourceDir.set(compileSourceDir)
+    outputDir.set(headerOutputDir.map { it.dir("$language/$taskSuffix") })
 
-      outputDir.set(headerOutputDir.map { it.dir("java/$sourceSetName") })
+    group = GROUP
+    description = "Generates $language JNI headers from class files for $sourceSetName compilation."
 
-      group = GROUP
-      description = "Generates Java JNI headers from class files for $sourceSetName compilation."
-
-      doFirst {
-        logger.info("Ktjni - running $taskName")
-      }
+    doFirst {
+      logger.info("Ktjni - running $taskName")
     }
-
-    aggregate.from(generateJniHeadersTask.flatMap { it.outputDir })
   }
 
-  private fun Project.registerScalaHeaderTask(
-    sourceSetName: String,
-    compileTaskProvider: TaskProvider<ScalaCompile>,
-    headerOutputDir: DirectoryProperty,
-    aggregate: ConfigurableFileCollection,
-  ) {
-    val taskName = "generateScala${sourceSetName.titleCase}JniHeaders"
-    val generateJniHeadersTask = tasks.register(taskName, KtjniTask::class.java) {
-      sourceDir.set(
-        compileTaskProvider.flatMap { it.destinationDirectory },
-      )
-
-      outputDir.set(headerOutputDir.map { it.dir("scala/$sourceSetName") })
-
-      group = GROUP
-      description = "Generates Scala JNI headers from class files for $sourceSetName compilation."
-
-      doFirst {
-        logger.info("Ktjni - running $taskName")
-      }
-    }
-
-    aggregate.from(generateJniHeadersTask.flatMap { it.outputDir })
-  }
+  aggregate.from(generateJniHeadersTask.flatMap { it.outputDir })
 }

--- a/plugin/src/main/kotlin/io/github/fletchmckee/ktjni/internal/android.kt
+++ b/plugin/src/main/kotlin/io/github/fletchmckee/ktjni/internal/android.kt
@@ -6,13 +6,11 @@ import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.ComponentIdentity
 import com.android.build.api.variant.HasAndroidTest
 import com.android.build.api.variant.HasUnitTest
-import io.github.fletchmckee.ktjni.tasks.KtjniTask
-import io.github.fletchmckee.ktjni.util.GROUP
+import io.github.fletchmckee.ktjni.registerKtjniTask
 import io.github.fletchmckee.ktjni.util.titleCase
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.JavaCompile
 
 internal fun Project.configureAndroidVariants(
@@ -36,45 +34,19 @@ private fun Project.findJavaCompilationTask(
   headerOutputDir: DirectoryProperty,
   aggregate: ConfigurableFileCollection,
 ) {
-  // Generally trying to avoid string matching for task types, but this is a pattern you'll see in other plugins like room-gradle-plugin
-  // See AndroidPluginIntegration.kt
   val compileTaskName = "compile${variant.name.titleCase}JavaWithJavac"
-  tasks.withType(JavaCompile::class.java).all {
-    if (name == compileTaskName) {
-      val compileTaskProvider = tasks.named(compileTaskName, JavaCompile::class.java)
-      registerJavaHeaderTask(
-        sourceSetName = variant.name,
-        compileTaskProvider = compileTaskProvider,
-        headerOutputDir = headerOutputDir,
-        aggregate = aggregate,
-      )
-    }
-  }
-}
-
-// For now we'll have duplicate methods until I can figure out a better way to clean this up.
-private fun Project.registerJavaHeaderTask(
-  sourceSetName: String,
-  compileTaskProvider: TaskProvider<JavaCompile>,
-  headerOutputDir: DirectoryProperty,
-  aggregate: ConfigurableFileCollection,
-) {
-  val taskName = "generateJava${sourceSetName.titleCase}JniHeaders"
-
-  val generateJniHeadersTask = tasks.register(taskName, KtjniTask::class.java) {
-    sourceDir.set(
-      compileTaskProvider.flatMap { it.destinationDirectory },
-    )
-
-    outputDir.set(headerOutputDir.map { it.dir("java/$sourceSetName") })
-
-    group = GROUP
-    description = "Generates Java JNI headers from class files for $sourceSetName compilation."
-
-    doFirst {
-      logger.info("Ktjni - running $taskName")
-    }
+  // Defers task lookup until execution since the task won't exist yet.
+  val compileSourceDir = providers.provider {
+    tasks.named(compileTaskName, JavaCompile::class.java)
+  }.flatMap { taskProvider ->
+    taskProvider.flatMap { task -> task.destinationDirectory }
   }
 
-  aggregate.from(generateJniHeadersTask.flatMap { it.outputDir })
+  registerKtjniTask(
+    language = "java",
+    sourceSetName = variant.name,
+    compileSourceDir = compileSourceDir,
+    headerOutputDir = headerOutputDir,
+    aggregate = aggregate,
+  )
 }

--- a/plugin/src/main/kotlin/io/github/fletchmckee/ktjni/internal/kotlin.kt
+++ b/plugin/src/main/kotlin/io/github/fletchmckee/ktjni/internal/kotlin.kt
@@ -2,17 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.fletchmckee.ktjni.internal
 
-import io.github.fletchmckee.ktjni.tasks.KtjniTask
-import io.github.fletchmckee.ktjni.util.GROUP
-import io.github.fletchmckee.ktjni.util.taskSuffix
-import io.github.fletchmckee.ktjni.util.titleCase
+import io.github.fletchmckee.ktjni.registerKtjniTask
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
 
 internal fun Project.configureKotlinMultiplatform(
@@ -20,12 +16,18 @@ internal fun Project.configureKotlinMultiplatform(
   aggregate: ConfigurableFileCollection,
 ) {
   val kotlinExtension = extensions.getByType(KotlinMultiplatformExtension::class.java)
-  kotlinExtension.targets.all {
-    compilations.all {
+  kotlinExtension.targets.configureEach {
+    compilations.configureEach {
       // The only KMP platforms we need registrations for are `jvm` or `androidJvm`.
       if (platformType.name == "jvm" || platformType.name == "androidJvm") {
-        registerKotlinCompilationHeaderTask(
-          compilation = this,
+        val compileSourceDir = compileTaskProvider.flatMap { compileTask ->
+          (compileTask as AbstractKotlinCompile<*>).destinationDirectory
+        }
+
+        registerKtjniTask(
+          language = "kotlin",
+          sourceSetName = name,
+          compileSourceDir = compileSourceDir,
           headerOutputDir = headerOutputDir,
           aggregate = aggregate,
           target = target.name,
@@ -40,9 +42,15 @@ internal fun Project.configureKotlinJvm(
   aggregate: ConfigurableFileCollection,
 ) {
   val kotlinExtension = extensions.getByType(KotlinJvmProjectExtension::class.java)
-  kotlinExtension.target.compilations.all {
-    registerKotlinCompilationHeaderTask(
-      compilation = this,
+  kotlinExtension.target.compilations.configureEach {
+    val compileSourceDir = compileTaskProvider.flatMap { compileTask ->
+      (compileTask as AbstractKotlinCompile<*>).destinationDirectory
+    }
+
+    registerKtjniTask(
+      language = "kotlin",
+      sourceSetName = name,
+      compileSourceDir = compileSourceDir,
       headerOutputDir = headerOutputDir,
       aggregate = aggregate,
     )
@@ -54,39 +62,17 @@ internal fun Project.configureKotlinAndroid(
   aggregate: ConfigurableFileCollection,
 ) {
   val kotlinExtension = extensions.getByType(KotlinAndroidProjectExtension::class.java)
-  kotlinExtension.target.compilations.all {
-    registerKotlinCompilationHeaderTask(
-      compilation = this,
+  kotlinExtension.target.compilations.configureEach {
+    val compileSourceDir = compileTaskProvider.flatMap { compileTask ->
+      (compileTask as AbstractKotlinCompile<*>).destinationDirectory
+    }
+
+    registerKtjniTask(
+      language = "kotlin",
+      sourceSetName = name,
+      compileSourceDir = compileSourceDir,
       headerOutputDir = headerOutputDir,
       aggregate = aggregate,
     )
   }
-}
-
-private fun Project.registerKotlinCompilationHeaderTask(
-  compilation: KotlinCompilation<*>,
-  headerOutputDir: DirectoryProperty,
-  aggregate: ConfigurableFileCollection,
-  target: String = "", // For Kotlin Multiplatform
-) {
-  val taskSuffix = compilation.name.taskSuffix(target)
-  val taskName = "generateKotlin${taskSuffix.titleCase}JniHeaders"
-
-  val generateJniHeadersTask = tasks.register(taskName, KtjniTask::class.java) {
-    sourceDir.set(
-      compilation.compileTaskProvider.flatMap { compileTask ->
-        (compileTask as AbstractKotlinCompile<*>).destinationDirectory
-      },
-    )
-    outputDir.set(headerOutputDir.map { it.dir("kotlin/$taskSuffix") })
-
-    group = GROUP
-    description = "Generates Kotlin JNI headers from class files for ${compilation.name} compilation"
-
-    doFirst {
-      logger.info("Ktjni - running $taskName")
-    }
-  }
-
-  aggregate.from(generateJniHeadersTask.flatMap { it.outputDir })
 }

--- a/plugin/src/test/kotlin/io/github/fletchmckee/ktjni/KtjniPluginTest.kt
+++ b/plugin/src/test/kotlin/io/github/fletchmckee/ktjni/KtjniPluginTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import io.github.fletchmckee.ktjni.util.AndroidVersion
 import io.github.fletchmckee.ktjni.util.assertConfigurationCacheReused
 import io.github.fletchmckee.ktjni.util.assertJavaAndroidTestsNoSource
+import io.github.fletchmckee.ktjni.util.assertKmpAndroidTestsNoSource
 import io.github.fletchmckee.ktjni.util.assertKotlinAndroidTestsNoSource
 import io.github.fletchmckee.ktjni.util.assertNotIn
 import io.github.fletchmckee.ktjni.util.withAndroidConfiguration
@@ -14,7 +15,9 @@ import io.github.fletchmckee.ktjni.util.writeCommonSettingsFile
 import io.github.fletchmckee.ktjni.util.writeJavaAndroidLibraryBuildFile
 import io.github.fletchmckee.ktjni.util.writeJavaBuildFile
 import io.github.fletchmckee.ktjni.util.writeJavaExampleFile
+import io.github.fletchmckee.ktjni.util.writeKmpAndroidLibraryBuildFile
 import io.github.fletchmckee.ktjni.util.writeKmpBuildFile
+import io.github.fletchmckee.ktjni.util.writeKmpLegacyAndroidLibraryBuildFile
 import io.github.fletchmckee.ktjni.util.writeKotlinAndroidLibraryBuildFile
 import io.github.fletchmckee.ktjni.util.writeKotlinExampleFile
 import io.github.fletchmckee.ktjni.util.writeKotlinJvmBuildFile
@@ -66,6 +69,82 @@ class KtjniPluginTest {
 
     secondRun.assertConfigurationCacheReused()
     assertHeaders(projectRoot, "build/generated/ktjni/kotlin/jvmMain")
+  }
+
+  @ParameterizedTest
+  @EnumSource(AndroidVersion::class)
+  fun `plugin generates headers for Kotlin Multiplatform Android legacy AGP`(kotlinJdkVersion: AndroidVersion) {
+    srcDir = File(projectRoot, "src/main/kotlin/com/example").apply { mkdirs() }
+    testFile = File(srcDir, "Example.kt")
+    testFile.writeKotlinExampleFile()
+    buildFile.writeKmpLegacyAndroidLibraryBuildFile(kotlinJdkVersion)
+
+    val firstRun = createAndroidTestRunner(projectRoot).build()
+
+    assertThat(firstRun.task(":generateJniHeaders")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(firstRun.task(":generateKotlinAndroidDebugJniHeaders")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(firstRun.task(":generateKotlinAndroidReleaseJniHeaders")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertKmpAndroidTestsNoSource(firstRun)
+
+    val secondRun = createAndroidTestRunner(projectRoot).build()
+    // Verify tasks are restored from cache.
+    assertThat(secondRun.task(":generateJniHeaders")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+    assertThat(secondRun.task(":generateKotlinAndroidDebugJniHeaders")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+    assertThat(secondRun.task(":generateKotlinAndroidReleaseJniHeaders")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+    assertKmpAndroidTestsNoSource(secondRun)
+
+    secondRun.assertConfigurationCacheReused()
+    assertHeaders(projectRoot, "build/generated/ktjni/kotlin/androidDebug")
+    assertHeaders(projectRoot, "build/generated/ktjni/kotlin/androidRelease")
+  }
+
+  @ParameterizedTest
+  @EnumSource(AndroidVersion::class)
+  fun `plugin generates commonMain headers for Kotlin Multiplatform Android legacy AGP`(kotlinJdkVersion: AndroidVersion) {
+    srcDir = File(projectRoot, "src/commonMain/kotlin/com/example").apply { mkdirs() }
+    testFile = File(srcDir, "Example.kt")
+    testFile.writeKotlinExampleFile()
+    buildFile.writeKmpLegacyAndroidLibraryBuildFile(kotlinJdkVersion)
+
+    val firstRun = createAndroidTestRunner(projectRoot).build()
+
+    assertThat(firstRun.task(":generateJniHeaders")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(firstRun.task(":generateKotlinAndroidDebugJniHeaders")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(firstRun.task(":generateKotlinAndroidReleaseJniHeaders")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertKmpAndroidTestsNoSource(firstRun)
+
+    val secondRun = createAndroidTestRunner(projectRoot).build()
+    // Verify tasks are restored from cache.
+    assertThat(secondRun.task(":generateJniHeaders")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+    assertThat(secondRun.task(":generateKotlinAndroidDebugJniHeaders")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+    assertThat(secondRun.task(":generateKotlinAndroidReleaseJniHeaders")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+    assertKmpAndroidTestsNoSource(secondRun)
+
+    secondRun.assertConfigurationCacheReused()
+    assertHeaders(projectRoot, "build/generated/ktjni/kotlin/androidDebug")
+    assertHeaders(projectRoot, "build/generated/ktjni/kotlin/androidRelease")
+  }
+
+  @ParameterizedTest
+  @EnumSource(AndroidVersion::class)
+  fun `plugin generates headers for KMP and Android KMP plugin`(kotlinAndroid: AndroidVersion) {
+    srcDir = File(projectRoot, "src/commonMain/kotlin/com/example").apply { mkdirs() }
+    testFile = File(srcDir, "Example.kt")
+    testFile.writeKotlinExampleFile()
+    buildFile.writeKmpAndroidLibraryBuildFile(kotlinAndroid)
+
+    val firstRun = createAndroidTestRunner(projectRoot).build()
+
+    assertThat(firstRun.task(":generateJniHeaders")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(firstRun.task(":generateKotlinAndroidMainJniHeaders")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val secondRun = createAndroidTestRunner(projectRoot).build()
+    // Verify tasks are restored from cache.
+    assertThat(secondRun.task(":generateJniHeaders")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+    assertThat(secondRun.task(":generateKotlinAndroidMainJniHeaders")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+
+    secondRun.assertConfigurationCacheReused()
+    assertHeaders(projectRoot, "build/generated/ktjni/kotlin/androidMain")
   }
 
   @ParameterizedTest

--- a/plugin/src/test/kotlin/io/github/fletchmckee/ktjni/util/androidUtil.kt
+++ b/plugin/src/test/kotlin/io/github/fletchmckee/ktjni/util/androidUtil.kt
@@ -40,6 +40,67 @@ internal fun GradleRunner.withAndroidConfiguration(projectRoot: File): GradleRun
     .withTestKitDir(File("build/gradle-test-kit").absoluteFile)
 }
 
+internal fun File.writeKmpLegacyAndroidLibraryBuildFile(kotlinAndroid: AndroidVersion) = writeText(
+  """
+  import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+  import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+  plugins {
+    id("com.android.library") version "8.13.2"
+    kotlin("multiplatform") version "${kotlinAndroid.kotlin}"
+    id("io.github.fletchmckee.ktjni")
+  }
+
+  android {
+    compileSdk = 36
+    defaultConfig {
+      minSdk = 23
+      namespace = "com.example"
+    }
+
+    compileOptions {
+      sourceCompatibility = JavaVersion.VERSION_${kotlinAndroid.jdk}
+      targetCompatibility = JavaVersion.VERSION_${kotlinAndroid.jdk}
+    }
+  }
+
+  tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.valueOf("JVM_${kotlinAndroid.jdk}"))
+    }
+  }
+
+  kotlin {
+    androidTarget()
+  }
+  """.trimIndent(),
+)
+
+internal fun File.writeKmpAndroidLibraryBuildFile(kotlinAndroid: AndroidVersion) = writeText(
+  """
+  import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+  import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+  plugins {
+    id("com.android.kotlin.multiplatform.library") version "${kotlinAndroid.agp}"
+    kotlin("multiplatform") version "${kotlinAndroid.kotlin}"
+    id("io.github.fletchmckee.ktjni")
+  }
+
+  kotlin {
+    androidLibrary {
+      compileSdk { version = release(36) }
+      minSdk = 23
+      namespace = "com.example"
+
+      compilerOptions {
+        jvmTarget.set(JvmTarget.valueOf("JVM_${kotlinAndroid.jdk}"))
+      }
+    }
+  }
+  """.trimIndent(),
+)
+
 internal fun File.writeKotlinAndroidLibraryBuildFile(kotlinAndroid: AndroidVersion) = writeText(
   """
   import org.jetbrains.kotlin.gradle.dsl.JvmTarget

--- a/plugin/src/test/kotlin/io/github/fletchmckee/ktjni/util/testUtil.kt
+++ b/plugin/src/test/kotlin/io/github/fletchmckee/ktjni/util/testUtil.kt
@@ -92,7 +92,7 @@ internal fun File.writeKmpBuildFile(kotlinJdkVersion: KotlinJdkVersion) = writeT
 
   kotlin {
     jvm {
-      compilations.all {
+      compilations.configureEach {
         compilerOptions.configure {
           jvmTarget.set(JvmTarget.JVM_${kotlinJdkVersion.jdk})
         }
@@ -126,7 +126,7 @@ internal fun File.writeKotlinJvmBuildFile(kotlinJdkVersion: KotlinJdkVersion) = 
     targetCompatibility = JavaVersion.VERSION_${kotlinJdkVersion.jdk}
   }
 
-  tasks.withType<KotlinCompile> {
+  tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
       jvmTarget.set(JvmTarget.valueOf("JVM_${kotlinJdkVersion.jdk}"))
     }
@@ -185,6 +185,13 @@ internal fun assertKotlinAndroidTestsNoSource(result: BuildResult) {
   assertThat(result.task(":generateKotlinDebugAndroidTestJniHeaders")?.outcome).isEqualTo(TaskOutcome.NO_SOURCE)
   assertThat(result.task(":generateKotlinDebugUnitTestJniHeaders")?.outcome).isEqualTo(TaskOutcome.NO_SOURCE)
   assertThat(result.task(":generateKotlinReleaseUnitTestJniHeaders")?.outcome).isEqualTo(TaskOutcome.NO_SOURCE)
+}
+
+internal fun assertKmpAndroidTestsNoSource(result: BuildResult) {
+  // There is no ReleaseAndroidTest variant.
+  assertThat(result.task(":generateKotlinAndroidDebugAndroidTestJniHeaders")?.outcome).isEqualTo(TaskOutcome.NO_SOURCE)
+  assertThat(result.task(":generateKotlinAndroidDebugUnitTestJniHeaders")?.outcome).isEqualTo(TaskOutcome.NO_SOURCE)
+  assertThat(result.task(":generateKotlinAndroidReleaseUnitTestJniHeaders")?.outcome).isEqualTo(TaskOutcome.NO_SOURCE)
 }
 
 internal fun assertJavaAndroidTestsNoSource(result: BuildResult) {

--- a/samples/simple/build.gradle.kts
+++ b/samples/simple/build.gradle.kts
@@ -42,7 +42,7 @@ android {
     targetCompatibility = JavaVersion.VERSION_11
   }
 
-  tasks.withType<KotlinCompile> {
+  tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
       jvmTarget.set(JvmTarget.JVM_11)
     }


### PR DESCRIPTION
- I believe the plugin should no longer be using any eager task resolution. Some other plugins used throughout the project still do, but I believe only the ones out of my control.
- This also enabled using a shared `registerKtjniTask` for all platforms as we now just need the Provider<Directory>, which is really the only thing we needed previously.